### PR TITLE
making this controller action work

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -55,6 +55,7 @@ group :production do
 end
 
 group :development do
+  gem 'pry'
   # Access an interactive console on exception pages or by calling 'console' anywhere in the code.
   gem 'web-console', '>= 3.3.0'
   gem 'listen', '>= 3.0.5', '< 3.2'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -71,6 +71,7 @@ GEM
     chromedriver-helper (2.1.0)
       archive-zip (~> 0.10)
       nokogiri (~> 1.8)
+    coderay (1.1.2)
     coffee-rails (4.2.2)
       coffee-script (>= 2.2.0)
       railties (>= 4.0.0)
@@ -117,6 +118,9 @@ GEM
     nokogiri (1.10.1)
       mini_portile2 (~> 2.4.0)
     pg (0.21.0)
+    pry (0.12.2)
+      coderay (~> 1.1.0)
+      method_source (~> 0.9.0)
     public_suffix (3.0.3)
     puma (3.12.0)
     rack (2.0.6)
@@ -223,6 +227,7 @@ DEPENDENCIES
   jquery-rails
   listen (>= 3.0.5, < 3.2)
   pg (~> 0.11)
+  pry
   puma (~> 3.11)
   rails (~> 5.2.2)
   rails-controller-testing
@@ -240,4 +245,4 @@ RUBY VERSION
    ruby 2.5.1p57
 
 BUNDLED WITH
-   1.16.2
+   1.16.6

--- a/app/controllers/categories_controller.rb
+++ b/app/controllers/categories_controller.rb
@@ -14,7 +14,7 @@ class CategoriesController < ApplicationController
   end
 
   def create
-    @category = Category.new(category_params)
+    @category = Category.new(name: category_params[:name], user: current_user)
     if @category.save
       flash[:success] = "Category was created successfully"
       redirect_to categories_path


### PR DESCRIPTION
OK, mark. This thing works! Check it out:

![working](https://cl.ly/a84d64c9f38d/Screen%20Recording%202019-02-20%20at%2011.30%20PM.gif)

This PR adds the `pry` gem to your development group - that lets us stick a `binding.pry` at the top of your `CategoriesController#create` method, and inspect the inbound params, and see what's required to build the desired object. 

That was how I figured out that you needed two things:

1. to specify _which_ object attribute mapped to a given param
2. the `categories` object requires a `user`, which is now provided with `current_user`. 

This PR doesn't stand on its own - I'd very much like to discuss this in depth with you soon. Maybe tomorrow?